### PR TITLE
Fix Form types

### DIFF
--- a/src/components/form/types-forms.ts
+++ b/src/components/form/types-forms.ts
@@ -3,6 +3,7 @@ import {
   TextInputProps,
   NativeSyntheticEvent,
   TextInputFocusEventData,
+  ViewProps,
 } from "react-native";
 import {
   backgroundColor,
@@ -12,7 +13,6 @@ import {
   padding,
 } from "../../theme";
 import { getButtonStyle } from "../button/buttonVariants";
-import { getSpacingStyles } from "../../utils/getSpacingStyles";
 
 export type BaseInputProps = {
   id?: string;
@@ -20,7 +20,7 @@ export type BaseInputProps = {
   label?: string;
   type?: "text" | "password";
   placeholder?: string;
-  padding?: keyof typeof getSpacingStyles;
+  padding?: keyof typeof padding;
   bg?: keyof typeof backgroundColor;
   radius?: keyof typeof borderRadius;
   className?: object; // for passing style objects
@@ -43,10 +43,10 @@ export type BaseFormProps = {
   buttonTitle?: string;
   buttonVariant?: keyof typeof getButtonStyle;
   bg?: keyof typeof backgroundColor;
-  padding?: keyof typeof getSpacingStyles;
-  margin?: keyof typeof getSpacingStyles;
+  padding?: keyof typeof padding;
+  margin?: keyof typeof margin;
   shadow?: boolean;
   radius?: boolean;
   action?: string;
   className?: object;
-};
+} & ViewProps;


### PR DESCRIPTION
## Summary
- fix BaseFormProps and BaseInputProps type definitions for spacing tokens
- allow passing standard ViewProps to forms

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852dffd0f00832a977bdfbc0863ba7f