### PR TITLE
Fix Form types

### DIFF
--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -3,13 +3,19 @@ import { View } from "react-native";
 import { getSpacingStyles } from "../../utils/getSpacingStyles";
 import Button from "../button/Button";
 import Input from "./Input";
-import { BaseFormProps } from "./types-forms";
-import { backgroundColor, borderRadius, shadow as shadowStyles } from "../../theme";
+import { BaseFormProps, BaseInputProps } from "./types-forms";
+import {
+  backgroundColor,
+  borderRadius,
+  shadow as shadowStyles,
+  padding as paddingTokens,
+  margin as marginTokens,
+} from "../../theme";
 import { Subtitle } from "../typography";
 
 const Form: React.FC<BaseFormProps> = ({
   children,
-  fields = [],
+  fields = [] as BaseInputProps[],
   title,
   buttonTitle,
   buttonVariant = "primary",
@@ -21,7 +27,10 @@ const Form: React.FC<BaseFormProps> = ({
   className,
   ...rest
 }) => {
-  const spacingStyles = getSpacingStyles({ padding, margin });
+  const spacingStyles = getSpacingStyles({
+    padding: padding as keyof typeof paddingTokens,
+    margin: margin as keyof typeof marginTokens,
+  });
   const background = { backgroundColor: backgroundColor[bg] };
   const border = radius ? { borderRadius: borderRadius["lg"] } : {};
   const elevation = useShadow ? shadowStyles["md"] : {};
@@ -40,8 +49,8 @@ const Form: React.FC<BaseFormProps> = ({
     >
       {title && <Subtitle align="center">{title}</Subtitle>}
 
-      {fields.map((field) => (
-        <Input key={field.name} {...field} />
+      {fields.map((field, index) => (
+        <Input key={field.name ?? index.toString()} {...field} />
       ))}
 
       {children}

--- a/src/components/form/Input.tsx
+++ b/src/components/form/Input.tsx
@@ -4,7 +4,7 @@ import { getSpacingStyles } from "../../utils/getSpacingStyles";
 import { BaseInputProps } from "./types-forms";
 import { backgroundColor, borderRadius } from "../../theme";
 
-export default function Input({
+const Input: React.FC<BaseInputProps> = ({
   id,
   name,
   label,
@@ -16,7 +16,7 @@ export default function Input({
   radius = "md",
   className,
   ...rest
-}: BaseInputProps) {
+}: BaseInputProps) => {
   const spacing = getSpacingStyles({ padding });
 
   return (
@@ -44,4 +44,6 @@ export default function Input({
       />
     </View>
   );
-}
+};
+
+export default Input;

--- a/src/components/form/types-forms.ts
+++ b/src/components/form/types-forms.ts
@@ -3,6 +3,7 @@ import {
   TextInputProps,
   NativeSyntheticEvent,
   TextInputFocusEventData,
+  ViewProps,
 } from "react-native";
 import {
   backgroundColor,
@@ -12,7 +13,6 @@ import {
   padding,
 } from "../../theme";
 import { getButtonStyle } from "../button/buttonVariants";
-import { getSpacingStyles } from "../../utils/getSpacingStyles";
 
 export type BaseInputProps = {
   id?: string;
@@ -20,7 +20,7 @@ export type BaseInputProps = {
   label?: string;
   type?: "text" | "password";
   placeholder?: string;
-  padding?: keyof typeof getSpacingStyles;
+  padding?: keyof typeof padding;
   bg?: keyof typeof backgroundColor;
   radius?: keyof typeof borderRadius;
   className?: object; // for passing style objects
@@ -43,10 +43,10 @@ export type BaseFormProps = {
   buttonTitle?: string;
   buttonVariant?: keyof typeof getButtonStyle;
   bg?: keyof typeof backgroundColor;
-  padding?: keyof typeof getSpacingStyles;
-  margin?: keyof typeof getSpacingStyles;
+  padding?: keyof typeof padding;
+  margin?: keyof typeof margin;
   shadow?: boolean;
   radius?: boolean;
   action?: string;
   className?: object;
-};
+} & ViewProps;

--- a/src/components/typography/index.tsx
+++ b/src/components/typography/index.tsx
@@ -1,4 +1,4 @@
 export { default as BodyText } from "./BodyText";
 export { default as Subtitle } from "./Subtitle";
-export { default as Title } from "./title";
+export { default as Title } from "./Title";
 export { default as Caption } from "./CaptionText";


### PR DESCRIPTION
## Summary
- fix BaseFormProps and BaseInputProps type definitions for spacing tokens
- allow passing standard ViewProps to forms
- adjust Form and Input components to satisfy TypeScript
- fix incorrect import in typography index

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852dffd0f00832a977bdfbc0863ba7f